### PR TITLE
fix E and F buttons in processEvents ([4] is E and [5] is F)

### DIFF
--- a/JoystickShield.cpp
+++ b/JoystickShield.cpp
@@ -200,8 +200,8 @@ void JoystickShield::processEvents() {
     buttonStates[1] = digitalRead(pin_right_button) == LOW;
     buttonStates[2] = digitalRead(pin_down_button) == LOW;
     buttonStates[3] = digitalRead(pin_left_button) == LOW;
-    buttonStates[5] = digitalRead(pin_E_button) == LOW;
-    buttonStates[4] = digitalRead(pin_F_button) == LOW;
+    buttonStates[4] = digitalRead(pin_E_button) == LOW;
+    buttonStates[5] = digitalRead(pin_F_button) == LOW;
     buttonStates[6] = digitalRead(pin_joystick_button) == LOW;
 }
 


### PR DESCRIPTION
This merge request fixes a bug in processEvents. Buttons E and F are switched.

JoystickShield.h:153:

```
// order is up, right, down, left, e[4], f[5], joystick
bool buttonStates[7];
```

JoysickShield.cpp:456

```
bool JoystickShield::isEButton() {
    return buttonStates[4];
}
```

JoysickShield.cpp:464

```
bool JoystickShield::isFButton() {
    return buttonStates[5];
}
```
